### PR TITLE
Fix grad assignment and `grad` property read

### DIFF
--- a/nbs/03_backprop.ipynb
+++ b/nbs/03_backprop.ipynb
@@ -466,7 +466,8 @@
     "# Save for testing against later\n",
     "def get_grad(x): return x.g.clone()\n",
     "chks = w1,w2,b1,b2,x_train\n",
-    "grads = w1g,w2g,b1g,b2g,ig = map(get_grad, chks)"
+    "w1g,w2g,b1g,b2g,ig = map(get_grad, chks)\n",
+    "grads = w1g,w2g,b1g,b2g,ig"
    ]
   },
   {
@@ -483,7 +484,8 @@
    "outputs": [],
    "source": [
     "def mkgrad(x): return x.clone().requires_grad_(True)\n",
-    "ptgrads = w12,w22,b12,b22,xt2 = map(mkgrad, chks)"
+    "w12,w22,b12,b22,xt2 = map(mkgrad, chks)\n",
+    "ptgrads = w12,w22,b12,b22,xt2"
    ]
   },
   {
@@ -515,7 +517,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for a,b in zip(grads, ptgrads): test_close(a.grad, b, eps=0.01)"
+    "for a,b in zip(grads, ptgrads): test_close(a, b.grad, eps=0.01)"
    ]
   },
   {


### PR DESCRIPTION
Double assignment seems to do something different than expected in Python
Changing it to two statements fixes it.
This also reveals that the `grad` property is accessed at the wrong value.
