### PR TITLE
Fix console log

### DIFF
--- a/miniai/learner.py
+++ b/miniai/learner.py
@@ -63,7 +63,7 @@ class MetricsCB(Callback):
 
     def after_epoch(self, learn):
         log = {k:f'{v.compute():.3f}' for k,v in self.all_metrics.items()}
-        log['epoch'] = learn.epoch
+        log['epoch'] = str(learn.epoch)
         log['train'] = 'train' if learn.model.training else 'eval'
         self._log(log)
 

--- a/nbs/09_learner.ipynb
+++ b/nbs/09_learner.ipynb
@@ -609,7 +609,7 @@
     "\n",
     "    def after_epoch(self, learn):\n",
     "        log = {k:f'{v.compute():.3f}' for k,v in self.all_metrics.items()}\n",
-    "        log['epoch'] = learn.epoch\n",
+    "        log['epoch'] = str(learn.epoch)\n",
     "        log['train'] = 'train' if learn.model.training else 'eval'\n",
     "        self._log(log)\n",
     "\n",


### PR DESCRIPTION
`ConsoleMasterBar` (`fastprogress`) assumes string values in https://github.com/fastai/fastprogress/blob/master/fastprogress/fastprogress.py#L291 – in this case, `len(t)` failed because `epoch` was sent as an `int`.