### PR TITLE
Update 15_DDPM.ipynb

### DIFF
--- a/nbs/15_DDPM.ipynb
+++ b/nbs/15_DDPM.ipynb
@@ -262,6 +262,7 @@
     "class DDPMCB(TrainCB):\n",
     "    order = DeviceCB.order+1\n",
     "    def __init__(self, n_steps, beta_min, beta_max):\n",
+    "        super().__init__()
     "        self.n_steps,self.βmin,self.βmax = n_steps,beta_min,beta_max\n",
     "        # variance schedule, linearly increased with timestep\n",
     "        self.β = torch.linspace(self.βmin, self.βmax, self.n_steps)\n",
@@ -295,7 +296,7 @@
     "            ᾱ_t1 = self.ᾱ[t-1]  if t > 0 else torch.tensor(1)\n",
     "            b̄_t = 1 - self.ᾱ[t]\n",
     "            b̄_t1 = 1 - ᾱ_t1\n",
-    "            noise_pred = learn.model(x_t, t_batch).sample\n",
+    "            noise_pred = model(x_t, t_batch).sample\n",
     "            x_0_hat = ((x_t - b̄_t.sqrt() * noise_pred)/self.ᾱ[t].sqrt()).clamp(-1,1)\n",
     "            x0_coeff = ᾱ_t1.sqrt()*(1-self.α[t])/b̄_t\n",
     "            xt_coeff = self.α[t].sqrt()*b̄_t1/b̄_t\n",


### PR DESCRIPTION
(1) Breaking change 
added super().__init__() to DDPMCB so that self.n_inp in TrainCB gets initialized (TrainCB changed after the lesson and this change makes DDPMCB consistent with the new version of TrainCB)

(2) Non-breaking change 
deleted reference to global variable 'learn' because 'model' is already being passed to the method as a parameter, so, no need to refer to the global model