### PR TITLE
check norm as class not instance & reset before every epoch instead before every fit

### DIFF
--- a/miniai/init.py
+++ b/miniai/init.py
@@ -106,7 +106,7 @@ def lsuv_init(model, m, m_in, xb):
 
 # %% ../nbs/11_initializing.ipynb 114
 def conv(ni, nf, ks=3, stride=2, act=nn.ReLU, norm=None, bias=None):
-    if bias is None: bias = not isinstance(norm, (nn.BatchNorm1d,nn.BatchNorm2d,nn.BatchNorm3d))
+    if bias is None: bias = not (norm in (nn.BatchNorm1d,nn.BatchNorm2d,nn.BatchNorm3d))
     layers = [nn.Conv2d(ni, nf, stride=stride, kernel_size=ks, padding=ks//2, bias=bias)]
     if norm: layers.append(norm(nf))
     if act: layers.append(act())

--- a/nbs/09_learner.ipynb
+++ b/nbs/09_learner.ipynb
@@ -86,22 +86,7 @@
    "execution_count": null,
    "id": "b22868a9",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "25a1693df8844081b050b8bbdb5f00fa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/2 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "x,y = 'image','label'\n",
     "name = \"fashion_mnist\"\n",
@@ -182,6 +167,7 @@
     "        self.ns.append(n)\n",
     "\n",
     "    def one_epoch(self, train):\n",
+    "        self.accs,self.losses,self.ns = [],[],[]\n",
     "        self.model.training = train\n",
     "        dl = self.dls.train if train else self.dls.valid\n",
     "        for self.num,self.batch in enumerate(dl): self.one_batch()\n",
@@ -189,7 +175,6 @@
     "        print(self.epoch, self.model.training, sum(self.losses).item()/n, sum(self.accs).item()/n)\n",
     "    \n",
     "    def fit(self, n_epochs):\n",
-    "        self.accs,self.losses,self.ns = [],[],[]\n",
     "        self.model.to(def_device)\n",
     "        self.opt = self.opt_func(self.model.parameters(), self.lr)\n",
     "        self.n_epochs = n_epochs\n",
@@ -219,8 +204,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0 True 1.1753044270833333 0.5986833333333333\n",
-      "0 False 1.120328794642857 0.6135285714285714\n"
+      "0 True 1.1753022135416666 0.5987333333333333\n",
+      "0 False 0.790286328125 0.7031\n"
      ]
     }
    ],

--- a/nbs/11_initializing.ipynb
+++ b/nbs/11_initializing.ipynb
@@ -2181,7 +2181,7 @@
    "source": [
     "#|export\n",
     "def conv(ni, nf, ks=3, stride=2, act=nn.ReLU, norm=None, bias=None):\n",
-    "    if bias is None: bias = not isinstance(norm, (nn.BatchNorm1d,nn.BatchNorm2d,nn.BatchNorm3d))\n",
+    "    if bias is None: bias = not (norm in (nn.BatchNorm1d,nn.BatchNorm2d,nn.BatchNorm3d))\n",
     "    layers = [nn.Conv2d(ni, nf, stride=stride, kernel_size=ks, padding=ks//2, bias=bias)]\n",
     "    if norm: layers.append(norm(nf))\n",
     "    if act: layers.append(act())\n",
@@ -2702,7 +2702,7 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
Two changes
- Currently we are passing nn.BatchNorm as class not instance, therefore isinstance will not work. We have to compare nn.BatchNorm as class
- Currently we reset losses, accuracy, and ns before each fit. It should be done at the start of every epoch instead.